### PR TITLE
B-0 Avoid warnings when link lib with missing lib.pdb file

### DIFF
--- a/util/pl/VC-32.pl
+++ b/util/pl/VC-32.pl
@@ -162,8 +162,8 @@ else
 	}
 
 # generate symbols.pdb unconditionally
-$app_cflag.=" /Zi /Fd\$(TMP_D)/app";
-$lib_cflag.=" /Zi /Fd\$(TMP_D)/lib";
+$app_cflag.=" /Z7 /Fd\$(TMP_D)/app";
+$lib_cflag.=" /Z7 /Fd\$(TMP_D)/lib";
 $lflags.=" /debug";
 
 $lflags.=" /fixed" if ($fips && $FLAVOR !~ /WIN64/);


### PR DESCRIPTION
Put debug info into .lib file instead .pdb
